### PR TITLE
jwt token headers

### DIFF
--- a/Router/user.router.js
+++ b/Router/user.router.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { userDataClient } from '../src/utils/prisma/index.js';
+import { user_Data_Prisma } from '../src/utils/Rank_Sort.js';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcrypt';
 import authMiddleware from '../src/middlewares/auth.middleware.js';
@@ -12,7 +12,7 @@ router.post('/sign-up', async (req, res, next) => {
     const { account, password, passwordCheck, name } = req.body;
 
     // 아이디가 이미 있는지 확인하는 함수
-    const isExistAccount = await userDataClient.users.findFirst({
+    const isExistAccount = await user_Data_Prisma.users.findFirst({
       where: {
         account,
       },
@@ -53,7 +53,7 @@ router.post('/sign-up', async (req, res, next) => {
     const hashedPassword = await bcrypt.hash(password, 10);
 
     // 테이블에 데이터 추가
-    await userDataClient.users.create({
+    await user_Data_Prisma.users.create({
       data: {
         account,
         password: hashedPassword,
@@ -71,7 +71,7 @@ router.post('/sign-up', async (req, res, next) => {
 router.post('/sign-in', async (req, res, next) => {
   const { account, password } = req.body;
 
-  const user = await userDataClient.users.findFirst({ where: { account } });
+  const user = await user_Data_Prisma.users.findFirst({ where: { account } });
 
   // 아이디가 존재하지 않을때 발생하는 오류
   if (!user) {
@@ -85,7 +85,7 @@ router.post('/sign-in', async (req, res, next) => {
 
   // jwt 토큰 발급
   const token = jwt.sign({ id: user.id }, 'turtle-secret-key');
-  res.cookie('authorization', `Bearer ${token}`);
+  res.header('authorization', `Bearer ${token}`);
 
   return res.status(200).json({ message: '로그인에 성공했습니다.' });
 });
@@ -96,7 +96,7 @@ router.post('/buy_cash/:id', authMiddleware, async (req, res, next) => {
   const { cash } = req.body;
 
   try {
-    const user = await userDataClient.users.findFirst({
+    const user = await user_Data_Prisma.users.findFirst({
       where: {
         id: +id,
       },
@@ -105,12 +105,12 @@ router.post('/buy_cash/:id', authMiddleware, async (req, res, next) => {
       return res.status(403).json({ message: '내 계정이 아닙니다.' });
     }
 
-    await userDataClient.users.update({
+    await user_Data_Prisma.users.update({
       where: { id: +id },
       data: { cash: { increment: cash } },
     });
 
-    const updatedUsers = await userDataClient.users.findUnique({
+    const updatedUsers = await user_Data_Prisma.users.findUnique({
       where: { id: +id },
       select: { cash: true },
     });

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,10 +1,10 @@
 import jwt from 'jsonwebtoken';
-import { userDataClient } from '../utils/prisma/index.js';
+import { user_Data_Prisma } from '../utils/Rank_Sort.js';
 
 // 인증 미들웨어
 export default async function (req, res, next) {
   try {
-    const { authorization } = req.cookies;
+    const authorization = req.headers.authorization;
     if (!authorization)
       throw new Error('요청한 사용자의 토큰이 존재하지 않습니다.');
 
@@ -15,7 +15,7 @@ export default async function (req, res, next) {
     const decodedToken = jwt.verify(token, 'turtle-secret-key');
     const id = decodedToken.id;
 
-    const user = await userDataClient.users.findFirst({
+    const user = await user_Data_Prisma.users.findFirst({
       where: { id: +id },
     });
     if (!user) {

--- a/src/utils/Rank_Sort.js
+++ b/src/utils/Rank_Sort.js
@@ -1,6 +1,6 @@
 import { PrismaClient as UsersDataClient } from '../../prisma/user/generated/UserDataClient/index.js';
 
-const user_Data_Prisma = new UsersDataClient({
+export const user_Data_Prisma = new UsersDataClient({
   log: ['query', 'info', 'warn', 'error'],
 
   errorFormat: 'pretty',


### PR DESCRIPTION
jwt 토큰 쿠키로 전달하는 방식에서 헤더로 전달하는 방식으로 변경하였습니다.
src/utils/Rank_Sort.js 에 export 추가했습니다.
혹시 prisma client 사용하실때 userDataClient 이거 쓰시던분들은 user_Data_Prisma 로 바꾸셔야 합니다 !! 

그래서 insomnia 에서 인증/인가 할때 약간 귀찮아졌습니다...

방법을 알려드리자면 sign-in 을 성공적으로 했을때 response headers 보시면 authorization 의 value 에 jwt 토큰이 있을텐데
그걸 복사 붙혀넣기 해서 인증/인가가 필요한 API 에서 request headers에 
1. +Add 클릭
2. header 분에 Authorization  입력  / ctrl + spacebar 하시면 여러가지 나오는데 거기서  Authorization 찾으셔도 됩니다.
3. value 부분에 복사한 토큰 붙여넣기
하시고 평소대로 테스트 하시면 됩니다.

지금 토큰 타입이나 secret-key 같은건 그대로 노출되어 있지만 리팩토링 할때 dotenv 사용해서 숨길예정입니다!

궁금한점 있으시면 물어보셔도 됩니다 !!